### PR TITLE
AuthServiceImpl에서 의존하고 있던 Redis 의존성을 분리, Spring Data JPA를 위한 Adapter추가.

### DIFF
--- a/authentication/src/main/java/com/msa/authentication/domain/AuthenticationDomain.java
+++ b/authentication/src/main/java/com/msa/authentication/domain/AuthenticationDomain.java
@@ -1,0 +1,101 @@
+package com.msa.authentication.domain;
+
+import com.msa.authentication.entity.User;
+import lombok.Getter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class AuthenticationDomain {
+
+    public boolean verifyPassword(String rawPassword, String hashedPassword, BCryptPasswordEncoder encoder) {
+        return encoder.matches(rawPassword, hashedPassword);
+    }
+
+    public TokenPair generateTokenPair(String username) {
+        Date now = new Date();
+        String accessJti = UUID.randomUUID().toString();
+        String refreshJti = UUID.randomUUID().toString();
+
+        return new TokenPair(
+                createTokenInfo(username, accessJti, now, 1000 * 60 * 60, "access"),
+                createTokenInfo(username, refreshJti, now, 1000 * 60 * 60 * 24 * 7, "refresh")
+        );
+    }
+
+    private TokenInfo createTokenInfo(String username, String jti, Date issuedAt, long expirationMs, String type) {
+        Date expiration = new Date(issuedAt.getTime() + expirationMs);
+        return new TokenInfo(username, jti, issuedAt, expiration, type);
+    }
+
+    public AuthenticationResult authenticate(User user, String rawPassword, BCryptPasswordEncoder encoder) {
+        if (user == null) {
+            return AuthenticationResult.failure("User not found");
+        }
+
+        if (!user.isActive()) {
+            return AuthenticationResult.failure("User is inactive");
+        }
+
+        if (!verifyPassword(rawPassword, user.getPassword(), encoder)) {
+            return AuthenticationResult.failure("Wrong password");
+        }
+
+        return AuthenticationResult.success(user);
+    }
+
+    @Getter
+    public static class TokenPair {
+        private final TokenInfo accessToken;
+        private final TokenInfo refreshToken;
+
+        public TokenPair(TokenInfo accessToken, TokenInfo refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+
+    }
+
+    @Getter
+    public static class TokenInfo {
+        private final String username;
+        private final String jti;
+        private final Date issuedAt;
+        private final Date expiration;
+        private final String type;
+
+        public TokenInfo(String username, String jti, Date issuedAt, Date expiration, String type) {
+            this.username = username;
+            this.jti = jti;
+            this.issuedAt = issuedAt;
+            this.expiration = expiration;
+            this.type = type;
+        }
+
+    }
+
+    @Getter
+    public static class AuthenticationResult {
+        private final boolean success;
+        private final User user;
+        private final String errorMessage;
+
+        private AuthenticationResult(boolean success, User user, String errorMessage) {
+            this.success = success;
+            this.user = user;
+            this.errorMessage = errorMessage;
+        }
+
+        public static AuthenticationResult success(User user) {
+            return new AuthenticationResult(true, user, null);
+        }
+
+        public static AuthenticationResult failure(String errorMessage) {
+            return new AuthenticationResult(false, null, errorMessage);
+        }
+
+    }
+}

--- a/authentication/src/main/java/com/msa/authentication/entity/User.java
+++ b/authentication/src/main/java/com/msa/authentication/entity/User.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
@@ -28,4 +29,47 @@ public class User {
     private String email;
 
     private String phone;
+
+    @Builder.Default
+    private Boolean active = true;
+
+    // 도메인 로직: 비밀번호 검증
+    public boolean verifyPassword(String rawPassword, PasswordEncoder encoder) {
+        return encoder.matches(rawPassword, this.password);
+    }
+
+    // 도메인 로직: 사용자 활성 상태 확인
+    public boolean isActive() {
+        return this.active != null && this.active;
+    }
+
+    // 도메인 로직: 사용자 정보 유효성 검증
+    public boolean isValidUser() {
+        return this.username != null && !this.username.trim().isEmpty() &&
+               this.password != null && !this.password.trim().isEmpty() &&
+               this.email != null && !this.email.trim().isEmpty();
+    }
+
+    // 도메인 로직: 사용자 비활성화
+    public void deactivate() {
+        this.active = false;
+    }
+
+    // 도메인 로직: 사용자 활성화
+    public void activate() {
+        this.active = true;
+    }
+
+    // 도메인 로직: 비밀번호 변경 (해싱된 비밀번호로)
+    public User changePassword(String newHashedPassword) {
+        return User.builder()
+                .id(this.id)
+                .username(this.username)
+                .password(newHashedPassword)
+                .name(this.name)
+                .email(this.email)
+                .phone(this.phone)
+                .active(this.active)
+                .build();
+    }
 }

--- a/authentication/src/main/java/com/msa/authentication/logic/JwtProvider.java
+++ b/authentication/src/main/java/com/msa/authentication/logic/JwtProvider.java
@@ -1,14 +1,16 @@
 package com.msa.authentication.logic;
 
 import com.msa.authentication.dto.response.AuthResult;
+import com.msa.authentication.outbound.port.TokenStorage;
+import com.msa.authentication.domain.AuthenticationDomain;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
 
@@ -18,36 +20,39 @@ public class JwtProvider {
 
     private static final String SECRET_KEY = "secret-key";
     private static final long ACCESS_EXPIRATION = 1000 * 60 * 60;
-    private static final long REFRESH_EXPIRATION = 1000 * 60 * 60 * 24;
+    private static final long REFRESH_EXPIRATION = 1000 * 60 * 60 * 24 * 7;
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final TokenStorage tokenStorage;
 
     public String generateAccessToken(String username) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + ACCESS_EXPIRATION);
-        String jti = UUID.randomUUID().toString();
-
-        return Jwts.builder()
-                .setSubject(username)
-                .setIssuedAt(now)
-                .setId(jti)
-                .claim("type", "access")
-                .setExpiration(expiryDate)
-                .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
-                .compact();
+        AuthenticationDomain.TokenInfo tokenInfo = createTokenInfo(username, "access", ACCESS_EXPIRATION);
+        return buildJwtToken(tokenInfo);
     }
 
     public String generateRefreshToken(String username) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + REFRESH_EXPIRATION);
-        String jti = UUID.randomUUID().toString();
+        AuthenticationDomain.TokenInfo tokenInfo = createTokenInfo(username, "refresh", REFRESH_EXPIRATION);
+        String token = buildJwtToken(tokenInfo);
 
+        tokenStorage.saveRefreshToken(username, token, Duration.ofMillis(REFRESH_EXPIRATION));
+        
+        return token;
+    }
+
+    private AuthenticationDomain.TokenInfo createTokenInfo(String username, String type, long expirationMs) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expirationMs);
+        String jti = UUID.randomUUID().toString();
+        
+        return new AuthenticationDomain.TokenInfo(username, jti, now, expiration, type);
+    }
+
+    private String buildJwtToken(AuthenticationDomain.TokenInfo tokenInfo) {
         return Jwts.builder()
-                .setSubject(username)
-                .setIssuedAt(now)
-                .setId(jti)
-                .claim("type", "refresh")
-                .setExpiration(expiryDate)
+                .setSubject(tokenInfo.getUsername())
+                .setIssuedAt(tokenInfo.getIssuedAt())
+                .setId(tokenInfo.getJti())
+                .claim("type", tokenInfo.getType())
+                .setExpiration(tokenInfo.getExpiration())
                 .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -65,8 +70,7 @@ public class JwtProvider {
             String tokenType = claims.get("type", String.class);
 
             if ("refresh".equals(tokenType)) {
-                String blacklistKey = "blacklist:refresh:" + jti;
-                if (Boolean.TRUE.equals(redisTemplate.hasKey(blacklistKey))) {
+                if (tokenStorage.isBlacklisted(jti)) {
                     return new AuthResult(false, subject, jti);
                 }
             }
@@ -92,23 +96,37 @@ public class JwtProvider {
         }
     }
 
-    public Date getAccessExpiration(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+    public Date getTokenExpiration(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
 
-        return claims.getExpiration();
+            return claims.getExpiration();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
-    public Date getRefreshExpiration(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+    public void tokenToBlacklist(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
 
-        return claims.getExpiration();
+            String jti = claims.getId();
+            Date expiration = claims.getExpiration();
+            long remainingTime = expiration.getTime() - System.currentTimeMillis();
+            
+            if (remainingTime > 0) {
+                tokenStorage.tokenToBlacklist(jti, Duration.ofMillis(remainingTime));
+            }
+        } catch (Exception e) {
+            // 토큰이 유효하지 않으면 블랙리스트에 추가할 필요 없음
+        }
     }
 }

--- a/authentication/src/main/java/com/msa/authentication/outbound/adapter/JpaUserAdapter.java
+++ b/authentication/src/main/java/com/msa/authentication/outbound/adapter/JpaUserAdapter.java
@@ -1,0 +1,21 @@
+package com.msa.authentication.outbound.adapter;
+
+import com.msa.authentication.entity.User;
+import com.msa.authentication.outbound.port.UserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaUserAdapter implements UserPort {
+
+    private final SpringDataUserRepository springDataUserRepository;
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        return springDataUserRepository.findByUsername(username);
+    }
+
+} 

--- a/authentication/src/main/java/com/msa/authentication/outbound/adapter/RedisTokenStorageAdapter.java
+++ b/authentication/src/main/java/com/msa/authentication/outbound/adapter/RedisTokenStorageAdapter.java
@@ -1,0 +1,48 @@
+package com.msa.authentication.outbound.adapter;
+
+import com.msa.authentication.outbound.port.TokenStorage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisTokenStorageAdapter implements TokenStorage {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void saveRefreshToken(String username, String token, Duration expiry) {
+        String key = "refresh:" + username;
+        redisTemplate.opsForValue().set(key, token, expiry.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Optional<String> getRefreshToken(String username) {
+        String key = "refresh:" + username;
+        String token = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(token);
+    }
+
+    @Override
+    public void tokenToBlacklist(String jti, Duration expiry) {
+        String key = "blacklist:refresh:" + jti;
+        redisTemplate.opsForValue().set(key, "blacklisted", expiry.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public boolean isBlacklisted(String jti) {
+        String key = "blacklist:refresh:" + jti;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    @Override
+    public void removeRefreshToken(String username) {
+        String key = "refresh:" + username;
+        redisTemplate.delete(key);
+    }
+} 

--- a/authentication/src/main/java/com/msa/authentication/outbound/adapter/SpringDataUserRepository.java
+++ b/authentication/src/main/java/com/msa/authentication/outbound/adapter/SpringDataUserRepository.java
@@ -1,11 +1,10 @@
-package com.msa.authentication.outbound.port;
+package com.msa.authentication.outbound.adapter;
 
 import com.msa.authentication.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
-
+interface SpringDataUserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
-}
+} 

--- a/authentication/src/main/java/com/msa/authentication/outbound/port/TokenStorage.java
+++ b/authentication/src/main/java/com/msa/authentication/outbound/port/TokenStorage.java
@@ -1,0 +1,12 @@
+package com.msa.authentication.outbound.port;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface TokenStorage {
+    void saveRefreshToken(String username, String token, Duration expiry);
+    Optional<String> getRefreshToken(String username);
+    void tokenToBlacklist(String jti, Duration expiry);
+    boolean isBlacklisted(String jti);
+    void removeRefreshToken(String username);
+} 

--- a/authentication/src/main/java/com/msa/authentication/outbound/port/UserPort.java
+++ b/authentication/src/main/java/com/msa/authentication/outbound/port/UserPort.java
@@ -1,0 +1,8 @@
+package com.msa.authentication.outbound.port;
+
+import com.msa.authentication.entity.User;
+import java.util.Optional;
+
+public interface UserPort {
+    Optional<User> findByUsername(String username);
+} 


### PR DESCRIPTION
1. 커서의 도움을 받아 Domain 주도 개발을 배웠음.
 - 이 부분은 더 써보면서 이해해야함 아직 모호함
2. Spring Data JPA를 사용하는 경우 Port와 Adapter를 확실하게 분리해서 통합된 시스템이 아닌 의존성을 최대한 낮추도록 설계해야함
3. AuthServiceImpl와 JwtProvider는 RedisTemplate을 의존하고 있었는데 이 부분을 TokenStorage라는 Port와 이를 구현한 Adapter인 RedisTemplateStorageAdapter로 구분지었음
 - 헥사고날 아키텍처의 기본은 Port만 의존하도록 하고 Adapter를 그때그때 갈아끼울 수 있도록 하는 것으로 보임
 - 만약 Redis가 아닌 Memcached라던가 DynamoDB같은 다른 Key Value 데이터베이스로 변경하는 경우를 대비함